### PR TITLE
Retry the initial connection to the server

### DIFF
--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -75,6 +75,19 @@ func NewClient(cfg *Config) *Client {
 		log.Fatal(err)
 	}
 
+	maxAttempts := 20
+	for attempts := 1; attempts <= maxAttempts; attempts++ {
+		err = db.Ping()
+		if err == nil {
+			break
+		}
+		log.Infof("Fail to connect (%d/%d attempts): %v", attempts, maxAttempts, err)
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		log.Fatal("Can't connect to the PostgreSQL server")
+	}
+
 	db.SetMaxOpenConns(cfg.maxOpenConns)
 	db.SetMaxIdleConns(cfg.maxIdleConns)
 


### PR DESCRIPTION
The program tries to connect several times to the PostgreSQL server
instead of bailing out immediately.