### PR TITLE
Setting to en-US locale for correct error checking

### DIFF
--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -112,8 +112,12 @@ func (c *Client) setupPgPrometheus() error {
 
 	defer tx.Rollback()
 
-	_, err = tx.Exec("CREATE EXTENSION IF NOT EXISTS pg_prometheus")
+	_, err = tx.Exec("SET lc_messages TO 'en_US.UTF-8'")
+	if err != nil {
+		return err
+	}
 
+	_, err = tx.Exec("CREATE EXTENSION IF NOT EXISTS pg_prometheus")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
By default, Postgres returns an error in the language specified in
the system. Thus, errors validating for the string "already exists"
in the result of the function call `create_prometheus_table`
won't work.

For example, a string is returned in Russian:
"ОШИБКА:  отношение "metrics_labels" уже существует". The
"уже существует" substring will never pass the test and will always
return an error.

The easiest way to fix the error is to specify en_US encoding in a
Postgres session.