### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Then, start the prometheus-postgreSQL storage adapter using:
 ```
  docker run --name prometheus_postgresql_adapter --link pg_prometheus -d -p 9201:9201 \
  timescale/prometheus-postgresql-adapter:master \
- -pg-host=pg_prometheus \
- -pg-prometheus-log-samples
+ -pg.host=pg_prometheus \
+ -pg.prometheus-log-samples
 ```
 
 Finally, you can start Prometheus with:


### PR DESCRIPTION
Original readme had incorrect syntax for running the prometheus-postgreSQL storage adapter docker image.