### PR TITLE
Fix test compile/run problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ docker-push: docker-image
 	docker push $(ORGANIZATION)/$(TARGET):${BRANCH}
 
 test:
-	GOCACHE=off go test -v -race $(PKGS) -args -database=false
+	GOCACHE=off go test -v -race $(PKGS)
 
 clean:
 	go clean

--- a/postgresql/client_test.go
+++ b/postgresql/client_test.go
@@ -5,13 +5,12 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/go-kit/kit/log"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 )
 
 var (
-	database = flag.Bool("database", true, "run database integration tests")
+	database = flag.Bool("database", false, "run database integration tests")
 )
 
 func TestBuildCommand(t *testing.T) {
@@ -85,8 +84,7 @@ func TestWriteCommand(t *testing.T) {
 	}
 
 	c := &Client{
-		logger: log.NewNopLogger(),
-		db:     db,
+		db: db,
 		cfg: &Config{
 			table:                 "metrics",
 			copyTable:             "metrics_copy",


### PR DESCRIPTION
Due to refactoring logging one test failed to compile. 
Common test argument`-args -database=false` makes tests fail if it's not present as a flag.
Make integration tests non default option.