### PR TITLE
Add ORDER BY time when fetching metrics

### DIFF
--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -331,10 +331,6 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 				return nil, err
 			}
 
-			if c.cfg.pgPrometheusLogSamples {
-				log.Debug("time", time, "labels", labels, "name", name, "value", value)
-			}
-
 			key := labels.key(name)
 			ts, ok := labelsToSeries[key]
 
@@ -381,6 +377,9 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 	}
 	for _, ts := range labelsToSeries {
 		resp.Results[0].Timeseries = append(resp.Results[0].Timeseries, ts)
+		if c.cfg.pgPrometheusLogSamples {
+			log.Debug("timeseries", ts.String())
+		}
 	}
 
 	log.Debug("msg", "Returned response", "#timeseries", len(labelsToSeries))

--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -331,6 +331,8 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 				return nil, err
 			}
 
+			log.Debug("time", time, "labels", labels, "name", name, "value", value)
+
 			key := labels.key(name)
 			ts, ok := labelsToSeries[key]
 
@@ -464,7 +466,7 @@ func (c *Client) buildQuery(q *prompb.Query) (string, error) {
 	matchers = append(matchers, fmt.Sprintf("time >= '%v'", toTimestamp(q.StartTimestampMs).Format(time.RFC3339)))
 	matchers = append(matchers, fmt.Sprintf("time <= '%v'", toTimestamp(q.EndTimestampMs).Format(time.RFC3339)))
 
-	return fmt.Sprintf("SELECT time, name, value, labels FROM %s WHERE %s %s",
+	return fmt.Sprintf("SELECT time, name, value, labels FROM %s WHERE %s %s ORDER BY time",
 		c.cfg.table, strings.Join(matchers, " AND "), equalsPredicate), nil
 }
 

--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -331,7 +331,9 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 				return nil, err
 			}
 
-			log.Debug("time", time, "labels", labels, "name", name, "value", value)
+			if c.cfg.pgPrometheusLogSamples {
+				log.Debug("time", time, "labels", labels, "name", name, "value", value)
+			}
 
 			key := labels.key(name)
 			ts, ok := labelsToSeries[key]


### PR DESCRIPTION
This is more of a discussion on how to downsample/rollup metrics that are older than retention period.  I'm a noob when it comes to timescaledb so this may be an extremely naive way to do downsampling so if any experts out there has a better way to do it, I'm all ears :)

That said, the way we do downsampling is as such:

1. Run aggregate function (e.g., `AVG`) over a time period for which raw metrics need to be aggregated into buckets, and save the result to a temp table.  e.g.,

```
SELECT time_bucket(interval '30 minutes', time) AS tb, labels_id, AVG(value) AS value
INTO tmp_table
FROM metrics_values
GROUP BY tb, labels_id
HAVING tb > %(start_time)s AND tb < %(end_time)s
```

2. Delete raw metrics in the `metrics_values` table within the time range:

```
DELETE FROM metrics_values WHERE time > %(start_time)s AND time <%(end_time)s
```
3. INSERT downsampled metrics back to the `metrics_values` table:
```
INSERT INTO metrics_values (time, labels_id, value) SELECT * FROM tmp_table
```

4. Drop the temp table

What comes out of this process is that the downsampled metrics will be appended at the end of the `metrics_values` table.  The table itself does not declare a canonical ordering on the `time` column so when Prometheus does a `range_query`, the SQL query result will return `metrics_values` rows out of order if there are downsampled metrics in the time range, causing Prometheus to return the wrong metrics.

This PR adds the `ORDER BY time` clause so the `metrics_values` rows are always sorted by time.

I did a quick `EXPLAIN` on the two queries on a database:

Without `ORDER BY`:

```
postgres=# EXPLAIN SELECT * FROM metrics;
                                      QUERY PLAN                                      
--------------------------------------------------------------------------------------
 Hash Join  (cost=29.12..161.26 rows=1519 width=112)
   Hash Cond: (m.labels_id = l.id)
   ->  Append  (cost=0.00..109.18 rows=1519 width=20)
         ->  Seq Scan on metrics_values m  (cost=0.00..0.00 rows=1 width=20)
         ->  Seq Scan on _hyper_1_9_chunk m_1  (cost=0.00..47.04 rows=4 width=20)
         ->  Seq Scan on _hyper_1_10_chunk m_2  (cost=0.00..62.14 rows=1514 width=20)
   ->  Hash  (cost=18.50..18.50 rows=850 width=68)
         ->  Seq Scan on metrics_labels l  (cost=0.00..18.50 rows=850 width=68)
(8 rows)
```

With `ORDER BY`:
```
postgres=# EXPLAIN SELECT * FROM metrics ORDER BY time;
                                         QUERY PLAN                                         
--------------------------------------------------------------------------------------------
 Sort  (cost=241.53..245.33 rows=1519 width=112)
   Sort Key: m."time"
   ->  Hash Join  (cost=29.12..161.26 rows=1519 width=112)
         Hash Cond: (m.labels_id = l.id)
         ->  Append  (cost=0.00..109.18 rows=1519 width=20)
               ->  Seq Scan on metrics_values m  (cost=0.00..0.00 rows=1 width=20)
               ->  Seq Scan on _hyper_1_9_chunk m_1  (cost=0.00..47.04 rows=4 width=20)
               ->  Seq Scan on _hyper_1_10_chunk m_2  (cost=0.00..62.14 rows=1514 width=20)
         ->  Hash  (cost=18.50..18.50 rows=850 width=68)
               ->  Seq Scan on metrics_labels l  (cost=0.00..18.50 rows=850 width=68)
(10 rows)
```

It appears that they both inspect roughly the same amount of rows, so the performance impact should be minimal, right?

Again, I'm new to timescaledb and I'm not sure if that's the best way to do downsampling.  Happy to hear any suggestions!