### PR TITLE
Improve write performance

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 
+	"fmt"
 	"github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/prompb"
 )
@@ -103,8 +104,10 @@ func init() {
 
 func main() {
 	cfg := parseFlags()
-	http.Handle(cfg.telemetryPath, prometheus.Handler())
 	log.Init(cfg.logLevel)
+	log.Info("config", fmt.Sprintf("%+v", cfg))
+
+	http.Handle(cfg.telemetryPath, prometheus.Handler())
 
 	writer, reader := buildClients(cfg)
 


### PR DESCRIPTION
For normalized table setup we skip using DB triggers (existing triggers in pg_prometheus appear to be slow), but write first into short lived temporary table and then inserting data into labels and values tables from there. Temporary table data is cleaned on each commit. Refactoring db tests to use the actual client creation logic.