### PR TITLE
Leader election for Prometheus HA setup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -215,6 +215,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8d6dc407d12ee5fe6e64d4e9476e41e16d7ce4e477015d8443b8b21247df2655"
+  inputs-digest = "e7dac0745b368eab3f4a3c695ecf4175450cf073e16cdd7b116cf41c9f64be0a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -64,7 +64,7 @@ func ParseFlags(cfg *Config) *Config {
 
 // Client sends Prometheus samples to PostgreSQL
 type Client struct {
-	db  *sql.DB
+	DB  *sql.DB
 	cfg *Config
 }
 
@@ -101,7 +101,7 @@ func NewClient(cfg *Config) *Client {
 	db.SetMaxIdleConns(cfg.maxIdleConns)
 
 	client := &Client{
-		db:  db,
+		DB:  db,
 		cfg: cfg,
 	}
 
@@ -121,7 +121,7 @@ func NewClient(cfg *Config) *Client {
 }
 
 func (c *Client) setupPgPrometheus() error {
-	tx, err := c.db.Begin()
+	tx, err := c.DB.Begin()
 
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func metricString(m model.Metric) string {
 // Write implements the Writer interface and writes metric samples to the database
 func (c *Client) Write(samples model.Samples) error {
 	begin := time.Now()
-	tx, err := c.db.Begin()
+	tx, err := c.DB.Begin()
 
 	if err != nil {
 		log.Error("msg", "Error on Begin when writing samples", "err", err)
@@ -360,7 +360,7 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 
 		log.Debug("msg", "Executed query", "query", command)
 
-		rows, err := c.db.Query(command)
+		rows, err := c.DB.Query(command)
 
 		if err != nil {
 			return nil, err
@@ -439,7 +439,7 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 
 // HealthCheck implements the healtcheck interface
 func (c *Client) HealthCheck() error {
-	rows, err := c.db.Query("SELECT 1")
+	rows, err := c.DB.Query("SELECT 1")
 
 	if err != nil {
 		log.Debug("msg", "Health check error", "err", err)

--- a/postgresql/client_test.go
+++ b/postgresql/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/timescale/prometheus-postgresql-adapter/log"
+	"github.com/timescale/prometheus-postgresql-adapter/util"
 	"testing"
 )
 
@@ -30,17 +31,17 @@ func TestBuildCommand(t *testing.T) {
 		StartTimestampMs: 0,
 		EndTimestampMs:   20000,
 		Matchers: []*prompb.LabelMatcher{
-			&prompb.LabelMatcher{
+			{
 				Type:  prompb.LabelMatcher_EQ,
 				Name:  "__name__",
 				Value: "cpu_usage",
 			},
-			&prompb.LabelMatcher{
+			{
 				Type:  prompb.LabelMatcher_EQ,
 				Name:  "job",
 				Value: "nginx",
 			},
-			&prompb.LabelMatcher{
+			{
 				Type:  prompb.LabelMatcher_RE,
 				Name:  "host",
 				Value: "local.*",
@@ -58,6 +59,130 @@ func TestBuildCommand(t *testing.T) {
 }
 
 func TestWriteCommand(t *testing.T) {
+	dbSetup(t)
+
+	cfg := &Config{}
+	ParseFlags(cfg)
+	cfg.database = *database
+
+	c := NewClient(cfg)
+
+	sample := []*model.Sample{
+		{
+			Metric: model.Metric{
+				model.MetricNameLabel: "test_metric",
+				"label1":              "1",
+			},
+			Value:     123.1,
+			Timestamp: 1234567,
+		},
+		{
+			Metric: model.Metric{
+				model.MetricNameLabel: "test_metric",
+				"label1":              "1",
+			},
+			Value:     123.2,
+			Timestamp: 1234568,
+		},
+		{
+			Metric: model.Metric{
+				model.MetricNameLabel: "test_metric",
+			},
+			Value:     123.2,
+			Timestamp: 1234569,
+		},
+		{
+			Metric: model.Metric{
+				model.MetricNameLabel: "test_metric_2",
+				"label1":              "1",
+			},
+			Value:     123.4,
+			Timestamp: 1234570,
+		},
+	}
+
+	c.Write(sample)
+
+	db, err := sql.Open("postgres", fmt.Sprintf("host=localhost dbname=%s user=postgres sslmode=disable", *database))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cnt int
+	err = db.QueryRow("SELECT count(*) FROM metrics").Scan(&cnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cnt != 4 {
+		t.Fatal("Wrong cnt: ", cnt)
+	}
+}
+
+func TestPgAdvisoryLock(t *testing.T) {
+	db := dbSetup(t)
+	lock, err := util.NewPgAdvisoryLock(1, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lock.Locked() {
+		t.Error("Couldn't obtain the lock")
+	}
+
+	newLock, err := util.NewPgAdvisoryLock(1, db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newLock.Locked() {
+		t.Error("Lock should have already been taken")
+	}
+
+	if err = lock.Release(); err != nil {
+		t.Errorf("Failed to release a lock. Error: %v", err)
+	}
+
+	if lock.Locked() {
+		t.Error("Should be unlocked after release")
+	}
+
+	newLock.TryLock()
+
+	if !newLock.Locked() {
+		t.Error("New lock should take over")
+	}
+}
+
+func TestElector(t *testing.T) {
+	db := dbSetup(t)
+	lock1, err := util.NewPgAdvisoryLock(1, db)
+	if err != nil {
+		t.Error(err)
+	}
+	elector1 := util.NewElector(lock1, false)
+	leader, _ := elector1.Elect()
+	if !leader {
+		t.Error("Failed to become a leader")
+	}
+
+	lock2, err := util.NewPgAdvisoryLock(1, db)
+	if err != nil {
+		t.Error(err)
+	}
+	elector2 := util.NewElector(lock2, false)
+	leader, _ = elector2.Elect()
+	if leader {
+		t.Error("Shouldn't be possible")
+	}
+
+	elector1.Resign()
+	leader, _ = elector2.Elect()
+	if !leader {
+		t.Error("Should become a leader")
+	}
+
+}
+
+func dbSetup(t *testing.T) *sql.DB {
 	flag.Parse()
 	if len(*database) == 0 {
 		t.Skip()
@@ -77,66 +202,5 @@ func TestWriteCommand(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = db.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &Config{}
-	ParseFlags(cfg)
-	cfg.database = *database
-
-	c := NewClient(cfg)
-
-	sample := []*model.Sample{
-		&model.Sample{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric",
-				"label1":              "1",
-			},
-			Value:     123.1,
-			Timestamp: 1234567,
-		},
-		&model.Sample{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric",
-				"label1":              "1",
-			},
-			Value:     123.2,
-			Timestamp: 1234568,
-		},
-		&model.Sample{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric",
-			},
-			Value:     123.2,
-			Timestamp: 1234569,
-		},
-		&model.Sample{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric_2",
-				"label1":              "1",
-			},
-			Value:     123.4,
-			Timestamp: 1234570,
-		},
-	}
-
-	c.Write(sample)
-
-	db, err = sql.Open("postgres", fmt.Sprintf("host=localhost dbname=%s user=postgres sslmode=disable", *database))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var cnt int
-	err = db.QueryRow("SELECT count(*) FROM metrics").Scan(&cnt)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if cnt != 4 {
-		t.Fatal("Wrong cnt: ", cnt)
-	}
+	return db
 }

--- a/util/election.go
+++ b/util/election.go
@@ -1,0 +1,195 @@
+package util
+
+import (
+	"fmt"
+	"github.com/timescale/prometheus-postgresql-adapter/log"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	electionInterval = time.Millisecond * 300
+)
+
+// Election defines an interface for adapter leader election.
+// If you are running Prometheus in HA mode where each Prometheus instance sends data to corresponding adapter you probably
+// want to allow writes into the database from only one adapter at the time. We need to elect a leader who can write to
+// the database. If leader goes down, another leader is elected. Look at `lock.go` for an implementation based on PostgreSQL
+// advisory locks. Should be easy to plug in different leader election implementations.
+type Election interface {
+	Id() string
+	BecomeLeader() (bool, error)
+	IsLeader() (bool, error)
+	Resign() error
+}
+
+// Elector is `Election` wrapper that provides cross-cutting concerns(eg. logging) and some common features shared among all election implementations.
+type Elector struct {
+	election  Election
+	scheduled bool
+	ticker    *time.Ticker
+}
+
+func NewElector(election Election, scheduled bool) *Elector {
+	var t *time.Ticker
+	if scheduled {
+		t = time.NewTicker(electionInterval)
+	}
+	elector := &Elector{election: election, ticker: t, scheduled: scheduled}
+	if scheduled {
+		go elector.scheduledElection()
+	}
+	return elector
+}
+
+func (e *Elector) Id() string {
+	return e.election.Id()
+}
+
+func (e *Elector) BecomeLeader() (bool, error) {
+	leader, err := e.election.BecomeLeader()
+	if err != nil {
+		log.Error("msg", "Error while trying to become a leader", "err", err)
+	}
+	if leader {
+		log.Info("msg", "Instance became a leader", "groupId", e.Id())
+	}
+	return leader, err
+}
+
+func (e *Elector) IsLeader() (bool, error) {
+	return e.election.IsLeader()
+}
+
+func (e *Elector) Resign() error {
+	err := e.election.Resign()
+	if err != nil {
+		log.Error("err", "Failed to resign", "err", err)
+	} else {
+		log.Info("msg", "Instance is not a leader anymore")
+	}
+	return err
+}
+
+func (e *Elector) scheduledElection() {
+	for {
+		select {
+		case <-e.ticker.C:
+			e.Elect()
+		}
+	}
+}
+
+func (e *Elector) Elect() (bool, error) {
+	leader, err := e.IsLeader()
+	if err != nil {
+		log.Error("msg", "Leader check failed", "err", err)
+	} else if !leader {
+		leader, err = e.BecomeLeader()
+		if err != nil {
+			log.Error("msg", "Failed while becoming a leader", "err", err)
+		}
+	}
+	return leader, err
+}
+
+// RestElection is a REST interface allowing to plug in any external leader election mechanism.
+// Remote service can use REST endpoints to manage leader election thus block or allow writes.
+type RestElection struct {
+	leader bool
+	mutex  sync.RWMutex
+}
+
+func NewRestElection() *RestElection {
+	r := &RestElection{}
+	http.Handle("/admin/election/leader", r.handleLeader())
+	return r
+}
+
+func (r *RestElection) handleLeader() http.HandlerFunc {
+	return func(response http.ResponseWriter, request *http.Request) {
+		switch request.Method {
+		case http.MethodGet:
+			leader, err := r.IsLeader()
+			if err != nil {
+				log.Error("msg", "Failed on leader check", "err", err)
+				http.Error(response, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprintf(response, "%v", leader)
+		case http.MethodPut:
+			body, err := ioutil.ReadAll(request.Body)
+			if err != nil {
+				log.Error("msg", "Error reading request body", "err", err)
+				http.Error(response, "Can't read body", http.StatusBadRequest)
+				return
+			}
+			flag, err := strconv.Atoi(string(body))
+			if err != nil {
+				log.Error("msg", "Error parsing to int", "body", string(body), "err", err)
+				http.Error(response, "1 or 0 expected in request body", http.StatusBadRequest)
+				return
+			}
+			switch flag {
+			case 0:
+				err = r.Resign()
+				if err != nil {
+					log.Error("err", err)
+					http.Error(response, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				fmt.Fprintf(response, "%v", true)
+			case 1:
+				leader, err := r.BecomeLeader()
+				if err != nil {
+					log.Error("msg", "Failed to become a leader", "err", err)
+					http.Error(response, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				fmt.Fprintf(response, "%v", leader)
+			default:
+				log.Error("msg", "Wrong number in request body", "body", string(body), "err", err)
+				http.Error(response, "1 or 0 expected in request body", http.StatusBadRequest)
+				return
+			}
+		default:
+			log.Error("msg", "Request method not supported")
+			http.Error(response, "Request method not supported", http.StatusBadRequest)
+		}
+	}
+}
+
+func (r *RestElection) Id() string {
+	return ""
+}
+
+func (r *RestElection) BecomeLeader() (bool, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.leader {
+		log.Warn("msg", "Instance is already a leader")
+		return r.leader, nil
+	}
+	r.leader = true
+	return r.leader, nil
+}
+
+func (r *RestElection) IsLeader() (bool, error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return r.leader, nil
+}
+
+func (r *RestElection) Resign() error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if !r.leader {
+		log.Warn("msg", "Can't resign when not a leader")
+		return nil
+	}
+	r.leader = false
+	return nil
+}

--- a/util/election_test.go
+++ b/util/election_test.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRestElection(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	re := NewRestElection()
+	if leader, _ := re.IsLeader(); leader {
+		t.Error("Initially there is no leader")
+	}
+	if leader, _ := re.BecomeLeader(); !leader {
+		t.Error("Failed to elect")
+	}
+	if leader, _ := re.IsLeader(); !leader {
+		t.Error("Failed to elect")
+	}
+	re.Resign()
+	if leader, _ := re.IsLeader(); leader {
+		t.Error("Failed to resign")
+	}
+}
+
+func TestRESTApi(t *testing.T) {
+	http.DefaultServeMux = new(http.ServeMux)
+	re := NewRestElection()
+	becomeLeaderReq, err := http.NewRequest("PUT", "/admin/leader", bytes.NewReader([]byte("1")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	re.handleLeader().ServeHTTP(recorder, becomeLeaderReq)
+
+	if recorder.Code != 200 {
+		t.Error("Expected HTTP 200 Status Code")
+	}
+	if recorder.Body.String() != "true" {
+		t.Error("Failed to become a leader")
+	}
+
+	leaderCheckReq, err := http.NewRequest("GET", "/admin/leader", nil)
+	recorder = httptest.NewRecorder()
+	re.handleLeader().ServeHTTP(recorder, leaderCheckReq)
+	if recorder.Body.String() != "true" {
+		t.Error("Instance should be leader")
+	}
+
+	resignReq, err := http.NewRequest("PUT", "/admin/leader", bytes.NewReader([]byte("0")))
+	recorder = httptest.NewRecorder()
+	re.handleLeader().ServeHTTP(recorder, resignReq)
+
+	if recorder.Code != 200 {
+		t.Error("Expected HTTP 200 Status Code")
+	}
+	if recorder.Body.String() != "true" {
+		t.Error("Failed to resign")
+	}
+}

--- a/util/lock.go
+++ b/util/lock.go
@@ -1,0 +1,156 @@
+package util
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/timescale/prometheus-postgresql-adapter/log"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	waitForConnectionTimeout = time.Second
+)
+
+// PgAdvisoryLock is implementation of leader election based on PostgreSQL advisory locks. All adapters withing a HA group are trying
+// to obtain an advisory lock for particular group. The one who holds the lock can write to the database. Due to the fact
+// that Prometheus HA setup provides no consistency guarantees this implementation is best effort in regards
+// to metrics that is written (some duplicates or data loss are possible during failover)
+type PgAdvisoryLock struct {
+	conn     *sql.Conn
+	mutex    sync.RWMutex
+	obtained bool
+	connPool *sql.DB
+
+	groupLockId int
+}
+
+func NewPgAdvisoryLock(groupLockId int, connPool *sql.DB) (*PgAdvisoryLock, error) {
+	lock := &PgAdvisoryLock{connPool: connPool, obtained: false, groupLockId: groupLockId}
+	_, err := lock.TryLock()
+	if err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
+func getConn(pool *sql.DB, cur, maxRetries int) (*sql.Conn, error) {
+	if maxRetries == cur {
+		return nil, fmt.Errorf("max attempts reached. giving up on getting a db connection")
+	}
+	ctx, _ := context.WithTimeout(context.Background(), waitForConnectionTimeout)
+	lockConn, err := pool.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting DB connection: %v", err)
+	}
+	err = checkConnection(lockConn)
+	if err != nil {
+		log.Error("msg", "Connection pool returned invalid connection", "err", err)
+		return getConn(pool, cur+1, maxRetries)
+	}
+	return lockConn, nil
+}
+
+func (l *PgAdvisoryLock) Id() string {
+	return strconv.Itoa(l.groupLockId)
+}
+
+func (l *PgAdvisoryLock) BecomeLeader() (bool, error) {
+	return l.TryLock()
+}
+
+func (l *PgAdvisoryLock) IsLeader() (bool, error) {
+	return l.Locked(), nil
+}
+
+func (l *PgAdvisoryLock) Resign() error {
+	return l.Release()
+}
+
+func (l *PgAdvisoryLock) TryLock() (bool, error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.obtained {
+		err := checkConnection(l.conn)
+		if err != nil {
+			l.obtained = false
+		} else {
+			return l.obtained, nil
+		}
+	}
+	var err error
+	l.conn, err = getConn(l.connPool, 0, 10)
+	defer func() {
+		if !l.obtained {
+			l.connCleanUp()
+		}
+	}()
+
+	if err != nil {
+		return false, err
+	}
+	rows, err := l.conn.QueryContext(context.Background(), "SELECT pg_try_advisory_lock($1)", l.groupLockId)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return false, fmt.Errorf("error while trying to read response rows from `pg_try_advisory_lock` function")
+	}
+	if err := rows.Scan(&l.obtained); err != nil {
+		return false, err
+	}
+	if l.obtained {
+		log.Debug("msg", fmt.Sprintf("Lock obtained for group id %d", l.groupLockId))
+	}
+	return l.obtained, nil
+}
+
+func (l *PgAdvisoryLock) connCleanUp() {
+	if l.conn != nil {
+		if err := l.conn.Close(); err != nil {
+			log.Error("err", err)
+		}
+	}
+	l.conn = nil
+}
+
+func (l *PgAdvisoryLock) Locked() bool {
+	l.mutex.RLock()
+	defer l.mutex.RUnlock()
+	return l.obtained
+}
+
+func (l *PgAdvisoryLock) Release() error {
+	l.mutex.Lock()
+	if !l.obtained {
+		return fmt.Errorf("can't release while not holding the lock")
+	}
+	defer l.mutex.Unlock()
+	rows, err := l.conn.QueryContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.groupLockId)
+	if err != nil {
+		return err
+	}
+	rows.Next()
+	var success bool
+	if err := rows.Scan(&success); err != nil {
+		return err
+	}
+	if !success {
+		return fmt.Errorf("failed to release a lock with group lock id: %v", l.groupLockId)
+	}
+	rows.Close()
+	l.connCleanUp()
+	l.obtained = false
+	return nil
+}
+
+func checkConnection(conn *sql.Conn) error {
+	_, err := conn.ExecContext(context.Background(), "SELECT 1")
+	if err != nil {
+		return fmt.Errorf("invalid connection: %v", err)
+	}
+	return nil
+}

--- a/util/util.go
+++ b/util/util.go
@@ -8,8 +8,8 @@ import (
 	"github.com/timescale/prometheus-postgresql-adapter/log"
 )
 
-//ThroughtputCalc runs on scheduled interval to calculate the throughput per second and sends results to a channel
-type ThroughtputCalc struct {
+//ThroughputCalc runs on scheduled interval to calculate the throughput per second and sends results to a channel
+type ThroughputCalc struct {
 	tickInterval time.Duration
 	previous     float64
 	current      chan float64
@@ -18,18 +18,18 @@ type ThroughtputCalc struct {
 	lock         sync.Mutex
 }
 
-func NewThroughputCalc(interval time.Duration) *ThroughtputCalc {
-	return &ThroughtputCalc{tickInterval: interval, current: make(chan float64, 1), Values: make(chan float64, 1)}
+func NewThroughputCalc(interval time.Duration) *ThroughputCalc {
+	return &ThroughputCalc{tickInterval: interval, current: make(chan float64, 1), Values: make(chan float64, 1)}
 }
 
-func (dt *ThroughtputCalc) SetCurrent(value float64) {
+func (dt *ThroughputCalc) SetCurrent(value float64) {
 	select {
 	case dt.current <- value:
 	default:
 	}
 }
 
-func (dt *ThroughtputCalc) Start() {
+func (dt *ThroughputCalc) Start() {
 	dt.lock.Lock()
 	defer dt.lock.Unlock()
 	if !dt.running {


### PR DESCRIPTION
 In HA setup two or more Prometheus instances scrape the same data and send it to adapters.
We want to prevent multiple adapters to write the same/similar data (no consistency guarantees in HA Prometheus setup) in parallel. The idea is to use leader election and allow only one adapter (leader) to write to the database. Provided leader election implementation relies on PostgreSQL advisory locks and does not provide strong data guarantees (some duplicates or data loss possible during failover). REST interface for leader election should enable plugging in any external leader election system you might use already (eg. Zookeeper, Consul...)