### PR TITLE
Monitor Prometheus liveness when PgAdvisoryLock is used

### DIFF
--- a/postgresql/client.go
+++ b/postgresql/client.go
@@ -244,7 +244,6 @@ func (c *Client) Write(samples model.Samples) error {
 		return err
 	}
 
-
 	if copyTable == fmt.Sprintf("%s_tmp", c.cfg.table) {
 		stmtLabels, err := tx.Prepare(fmt.Sprintf(sqlInsertLabels, c.cfg.table, c.cfg.table))
 		if err != nil {
@@ -281,7 +280,6 @@ func (c *Client) Write(samples model.Samples) error {
 		}
 	}
 
-
 	err = copyStmt.Close()
 	if err != nil {
 		log.Error("msg", "Error on COPY Close when writing samples", "err", err)
@@ -315,6 +313,14 @@ func createOrderedKeys(m *map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func (c *Client) Close() {
+	if c.DB != nil {
+		if err := c.DB.Close(); err != nil {
+			log.Error("msg", err.Error())
+		}
+	}
 }
 
 func (l *sampleLabels) Scan(value interface{}) error {

--- a/postgresql/client_test.go
+++ b/postgresql/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/timescale/prometheus-postgresql-adapter/log"
 	"github.com/timescale/prometheus-postgresql-adapter/util"
 	"testing"
+	"time"
 )
 
 var (
@@ -59,127 +60,160 @@ func TestBuildCommand(t *testing.T) {
 }
 
 func TestWriteCommand(t *testing.T) {
-	dbSetup(t)
+	withDB(t, func(db *sql.DB, t *testing.T) {
+		cfg := &Config{}
+		ParseFlags(cfg)
+		cfg.database = *database
 
-	cfg := &Config{}
-	ParseFlags(cfg)
-	cfg.database = *database
+		c := NewClient(cfg)
 
-	c := NewClient(cfg)
-
-	sample := []*model.Sample{
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric",
-				"label1":              "1",
+		sample := []*model.Sample{
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "test_metric",
+					"label1":              "1",
+				},
+				Value:     123.1,
+				Timestamp: 1234567,
 			},
-			Value:     123.1,
-			Timestamp: 1234567,
-		},
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric",
-				"label1":              "1",
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "test_metric",
+					"label1":              "1",
+				},
+				Value:     123.2,
+				Timestamp: 1234568,
 			},
-			Value:     123.2,
-			Timestamp: 1234568,
-		},
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric",
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "test_metric",
+				},
+				Value:     123.2,
+				Timestamp: 1234569,
 			},
-			Value:     123.2,
-			Timestamp: 1234569,
-		},
-		{
-			Metric: model.Metric{
-				model.MetricNameLabel: "test_metric_2",
-				"label1":              "1",
+			{
+				Metric: model.Metric{
+					model.MetricNameLabel: "test_metric_2",
+					"label1":              "1",
+				},
+				Value:     123.4,
+				Timestamp: 1234570,
 			},
-			Value:     123.4,
-			Timestamp: 1234570,
-		},
-	}
+		}
 
-	c.Write(sample)
+		c.Write(sample)
 
-	db, err := sql.Open("postgres", fmt.Sprintf("host=localhost dbname=%s user=postgres sslmode=disable", *database))
-	if err != nil {
-		t.Fatal(err)
-	}
+		var cnt int
+		err := c.DB.QueryRow("SELECT count(*) FROM metrics").Scan(&cnt)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	var cnt int
-	err = db.QueryRow("SELECT count(*) FROM metrics").Scan(&cnt)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if cnt != 4 {
-		t.Fatal("Wrong cnt: ", cnt)
-	}
+		if cnt != 4 {
+			t.Fatal("Wrong cnt: ", cnt)
+		}
+		c.Close()
+	})
 }
 
 func TestPgAdvisoryLock(t *testing.T) {
-	db := dbSetup(t)
-	lock, err := util.NewPgAdvisoryLock(1, db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !lock.Locked() {
-		t.Error("Couldn't obtain the lock")
-	}
+	withDB(t, func(db *sql.DB, t *testing.T) {
+		lock, err := util.NewPgAdvisoryLock(1, db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !lock.Locked() {
+			t.Error("Couldn't obtain the lock")
+		}
 
-	newLock, err := util.NewPgAdvisoryLock(1, db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if newLock.Locked() {
-		t.Error("Lock should have already been taken")
-	}
+		newLock, err := util.NewPgAdvisoryLock(1, db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if newLock.Locked() {
+			t.Error("Lock should have already been taken")
+		}
 
-	if err = lock.Release(); err != nil {
-		t.Errorf("Failed to release a lock. Error: %v", err)
-	}
+		if err = lock.Release(); err != nil {
+			t.Errorf("Failed to release a lock. Error: %v", err)
+		}
 
-	if lock.Locked() {
-		t.Error("Should be unlocked after release")
-	}
+		if lock.Locked() {
+			t.Error("Should be unlocked after release")
+		}
 
-	newLock.TryLock()
+		newLock.TryLock()
 
-	if !newLock.Locked() {
-		t.Error("New lock should take over")
-	}
+		if !newLock.Locked() {
+			t.Error("New lock should take over")
+		}
+	})
 }
 
 func TestElector(t *testing.T) {
+	withDB(t, func(db *sql.DB, t *testing.T) {
+		lock1, err := util.NewPgAdvisoryLock(2, db)
+		if err != nil {
+			t.Error(err)
+		}
+		elector1 := util.NewElector(lock1)
+		leader, _ := elector1.BecomeLeader()
+		if !leader {
+			t.Error("Failed to become a leader")
+		}
+
+		lock2, err := util.NewPgAdvisoryLock(2, db)
+		if err != nil {
+			t.Error(err)
+		}
+		elector2 := util.NewElector(lock2)
+		leader, _ = elector2.BecomeLeader()
+		if leader {
+			t.Error("Shouldn't be possible")
+		}
+
+		elector1.Resign()
+		leader, _ = elector2.BecomeLeader()
+		if !leader {
+			t.Error("Should become a leader")
+		}
+	})
+}
+
+func TestPromethuesLivenessCheck(t *testing.T) {
+	withDB(t, func(db *sql.DB, t *testing.T) {
+		lock1, err := util.NewPgAdvisoryLock(3, db)
+		if err != nil {
+			t.Error(err)
+		}
+		elector := util.NewScheduledElector(lock1)
+		leader, _ := elector.Elect()
+		if !leader {
+			t.Error("Failed to become a leader")
+		}
+		elector.PrometheusLivenessCheck(0, 0)
+		leader, _ = lock1.IsLeader()
+		if leader {
+			t.Error("Shouldn't be a leader")
+		}
+		if !elector.IsPausedScheduledElection() {
+			t.Error("Scheduled election should be paused")
+		}
+		elector.PrometheusLivenessCheck(time.Now().UnixNano(), time.Hour)
+		if elector.IsPausedScheduledElection() {
+			t.Error("Scheduled election shouldn't be paused anymore")
+		}
+	})
+}
+
+func withDB(t *testing.T, f func(db *sql.DB, t *testing.T)) {
 	db := dbSetup(t)
-	lock1, err := util.NewPgAdvisoryLock(1, db)
-	if err != nil {
-		t.Error(err)
-	}
-	elector1 := util.NewElector(lock1, false)
-	leader, _ := elector1.Elect()
-	if !leader {
-		t.Error("Failed to become a leader")
-	}
-
-	lock2, err := util.NewPgAdvisoryLock(1, db)
-	if err != nil {
-		t.Error(err)
-	}
-	elector2 := util.NewElector(lock2, false)
-	leader, _ = elector2.Elect()
-	if leader {
-		t.Error("Shouldn't be possible")
-	}
-
-	elector1.Resign()
-	leader, _ = elector2.Elect()
-	if !leader {
-		t.Error("Should become a leader")
-	}
-
+	defer func() {
+		if db != nil {
+			db.Close()
+		}
+	}()
+	f(db, t)
 }
 
 func dbSetup(t *testing.T) *sql.DB {

--- a/util/lock.go
+++ b/util/lock.go
@@ -17,7 +17,12 @@ const (
 // PgAdvisoryLock is implementation of leader election based on PostgreSQL advisory locks. All adapters withing a HA group are trying
 // to obtain an advisory lock for particular group. The one who holds the lock can write to the database. Due to the fact
 // that Prometheus HA setup provides no consistency guarantees this implementation is best effort in regards
-// to metrics that is written (some duplicates or data loss are possible during failover)
+// to metrics that is written (some duplicates or data loss are possible during fail-over)
+// `leader-election.pg-advisory-lock.prometheus-timeout` config must be set when using PgAdvisoryLock. It will
+// trigger leader resign (if instance is a leader) and will prevent an instance to become a leader if there are no requests coming
+// from Prometheus within a given timeout. Make sure to provide a reasonable value for the timeout (should be co-related with
+// Prometheus scrape interval, eg. 2x or 3x more then scrape interval to prevent leader flipping).
+// Recommended architecture when using PgAdvisoryLock is to have one adapter instance for one Prometheus instance.
 type PgAdvisoryLock struct {
 	conn     *sql.Conn
 	mutex    sync.RWMutex


### PR DESCRIPTION
Resign if Prometheus instance is not sending any data within configured timeout. If there is no data coming in from Prometheus, the adapter should not attempt to become a leader. Once Prometheus requests start coming in, the adapter should resume attempts to become a leader.