### PR TITLE
Fix primary key sequence growth for metric labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 *~
-/prometheus-postgresql-adapter
+/prometheus-postgresql-adapter*
 /vendor
 /version.properties
 /.target_os
 /.history
 /.vscode
+/.idea
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -215,6 +215,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e7dac0745b368eab3f4a3c695ecf4175450cf073e16cdd7b116cf41c9f64be0a"
+  inputs-digest = "f5312ede7b670bb664c97338901ed5ed758bfd04c7e665ff01d7d8a1695c2e73"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Insert metric labels only if they are not already present to prevent primary key sequence growing on each data point insert. 
Due to concurrency we can still get some conflicts (duplicate insert attempts for metrics labels), but that case would be quite rare and having some smaller gaps in the sequence shouldn't cause major troubles. 