### PR TITLE
Added Travis build file with job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,43 @@
+sudo: 'required'
+
 language: go
 
-go:
-  - 1.10.x
+services:
+  - 'docker'
+
+env:
+  global:
+  - ORGANIZATION=$DOCKER_USERNAME
+
+matrix:
+  include:
+  - go: "1.11.x"
+    env: VERSION=0.4.1
+fast_finish: true
 
 before_install:
   # We need golang/dep installed to resolve our dependencies
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - dep ensure
 
-script: make build test
+script: 
+  - 'make build test'
+  - 'make docker-image'
+
+after_success:
+  docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
+  make docker-push;
+  # - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+  #     docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
+  #     make docker-push;
+  #   else
+  #     echo "Build succeeded in non-master branch"
+  #   fi
+
+# Uncomment if only commits to master require builds
+# branches:
+#   except:
+#     - master
+
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-VERSION=$(shell git describe --always | sed 's|v\(.*\)|\1|')
-BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-OS:=$(shell uname -s | awk '{ print tolower($$1) }')
-ARCH=amd64
-ORGANIZATION=timescale
+VERSION?=$(shell git describe --always | sed 's|v\(.*\)|\1|')
+BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
+OS?=$(shell uname -s | awk '{ print tolower($$1) }')
+ARCH?=amd64
+ORGANIZATION?=timescale
 
 ifeq ($(shell uname -m), i386)
 	ARCH=386


### PR DESCRIPTION
Addresses https://github.com/timescale/prometheus-postgresql-adapter/issues/33

Proof of integration:
Travis Build: https://travis-ci.com/sgama/prometheus-postgresql-adapter/builds/98761312
Dockerhub Repository: https://hub.docker.com/r/solardesigner/prometheus-postgresql-adapter/tags

To get this CICD pipeline setup, you will first need to hook this repository into TravisCI.
Then configure the Environment Variables within the settings of the Travis Job for your Dockerhub repo.

I used the variables DOCKER_USERNAME and DOCKER_PASSWORD which contained the credentials for Dockerhub. Be sure to uncheck the slider for "Displaying value in the build log".

I left a few lines commented just in case you wanted to build dev branches as well.