### PR TITLE
Change Docker tags in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ docker image.
 
 To run this image use:
 ```
-docker run --name pg_prometheus -d -p 5432:5432 timescale/pg_prometheus:master postgres \
+docker run --name pg_prometheus -d -p 5432:5432 timescale/pg_prometheus:latest postgres \
       -csynchronous_commit=off
 ```
 
 Then, start the prometheus-postgreSQL storage adapter using:
 ```
  docker run --name prometheus_postgresql_adapter --link pg_prometheus -d -p 9201:9201 \
- timescale/prometheus-postgresql-adapter:master \
+ timescale/prometheus-postgresql-adapter:latest \
  -pg.host=pg_prometheus \
  -pg.prometheus-log-samples
 ```


### PR DESCRIPTION
Change both occurrences of master to latest.

master does not exist for pg_prometheus
latest tag for prometheus-postgresql-adapter is more up-to-date than master.