### PR TITLE
Generalize ARCH config in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 VERSION=$(shell git describe --always | sed 's|v\(.*\)|\1|')
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 OS:=$(shell uname -s | awk '{ print tolower($$1) }')
-ARCH=amd64
 ORGANIZATION=timescale
 
+ARCH=$(shell go env GOARCH)
+ifeq ($(ARCH),)
+  ARCH=amd64
+endif
 ifeq ($(shell uname -m), i386)
 	ARCH=386
 endif


### PR DESCRIPTION
The current Makefile only allows building AMD64 and i386, but there's no
reason why go can't build other archs. This setting of a specific arch
seems somewhat superfluous anyway since go provides us the proper arch
in its env, but I've retained the current behavior for safety if we
can't find the arch from go config.

The new default is to rely on GOARCH.