### PR TITLE
Add reccuring Postgres connection check for advisory lock

### DIFF
--- a/pkg/postgresql/client_test.go
+++ b/pkg/postgresql/client_test.go
@@ -4,16 +4,18 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/timescale/prometheus-postgresql-adapter/pkg/log"
 	"github.com/timescale/prometheus-postgresql-adapter/pkg/util"
-	"testing"
-	"time"
 )
 
 var (
-	database = flag.String("database", "", "database to run integration tests on")
+	database         = flag.String("database", "", "database to run integration tests on")
+	electionInterval = flag.Duration("election-interval", 5*time.Second, "Scheduled election interval")
 )
 
 func assertEqual(t *testing.T, s1 string, s2 string) {
@@ -237,7 +239,7 @@ func TestPrometheusLivenessCheck(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		elector := util.NewScheduledElector(lock1)
+		elector := util.NewScheduledElector(lock1, *electionInterval)
 		leader, _ := elector.Elect()
 		if !leader {
 			t.Error("Failed to become a leader")

--- a/pkg/util/election.go
+++ b/pkg/util/election.go
@@ -2,15 +2,14 @@ package util
 
 import (
 	"fmt"
-	"github.com/timescale/prometheus-postgresql-adapter/pkg/log"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
 	"time"
-)
 
-const electionInterval = time.Millisecond * 300
+	"github.com/timescale/prometheus-postgresql-adapter/pkg/log"
+)
 
 // Election defines an interface for adapter leader election.
 // If you are running Prometheus in HA mode where each Prometheus instance sends data to corresponding adapter you probably
@@ -18,7 +17,7 @@ const electionInterval = time.Millisecond * 300
 // the database. If leader goes down, another leader is elected. Look at `lock.go` for an implementation based on PostgreSQL
 // advisory locks. Should be easy to plug in different leader election implementations.
 type Election interface {
-	Id() string
+	ID() string
 	BecomeLeader() (bool, error)
 	IsLeader() (bool, error)
 	Resign() error
@@ -34,8 +33,8 @@ func NewElector(election Election) *Elector {
 	return elector
 }
 
-func (e *Elector) Id() string {
-	return e.election.Id()
+func (e *Elector) ID() string {
+	return e.election.ID()
 }
 
 func (e *Elector) BecomeLeader() (bool, error) {
@@ -44,7 +43,7 @@ func (e *Elector) BecomeLeader() (bool, error) {
 		log.Error("msg", "Error while trying to become a leader", "err", err)
 	}
 	if leader {
-		log.Info("msg", "Instance became a leader", "groupId", e.Id())
+		log.Info("msg", "Instance became a leader", "groupID", e.ID())
 	}
 	return leader, err
 }
@@ -70,7 +69,7 @@ type ScheduledElector struct {
 	pausedScheduledElection bool
 }
 
-func NewScheduledElector(election Election) *ScheduledElector {
+func NewScheduledElector(election Election, electionInterval time.Duration) *ScheduledElector {
 	scheduledElector := &ScheduledElector{Elector: Elector{election}, ticker: time.NewTicker(electionInterval)}
 	go scheduledElector.scheduledElection()
 	return scheduledElector
@@ -209,7 +208,7 @@ func (r *RestElection) handleLeader() http.HandlerFunc {
 	}
 }
 
-func (r *RestElection) Id() string {
+func (r *RestElection) ID() string {
 	return ""
 }
 

--- a/pkg/util/lock.go
+++ b/pkg/util/lock.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/timescale/prometheus-postgresql-adapter/pkg/log"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/timescale/prometheus-postgresql-adapter/pkg/log"
 )
 
 const (
@@ -24,16 +25,21 @@ const (
 // Prometheus scrape interval, eg. 2x or 3x more then scrape interval to prevent leader flipping).
 // Recommended architecture when using PgAdvisoryLock is to have one adapter instance for one Prometheus instance.
 type PgAdvisoryLock struct {
-	conn     *sql.Conn
+	conn        *sql.Conn
+	connPool    *sql.DB
+	groupLockID int
+
 	mutex    sync.RWMutex
 	obtained bool
-	connPool *sql.DB
-
-	groupLockId int
 }
 
-func NewPgAdvisoryLock(groupLockId int, connPool *sql.DB) (*PgAdvisoryLock, error) {
-	lock := &PgAdvisoryLock{connPool: connPool, obtained: false, groupLockId: groupLockId}
+// NewPgAdvisoryLock creates a new instance with specified lock ID, connection pool and lock timeout.
+func NewPgAdvisoryLock(groupLockID int, connPool *sql.DB) (*PgAdvisoryLock, error) {
+	lock := &PgAdvisoryLock{
+		connPool:    connPool,
+		obtained:    false,
+		groupLockID: groupLockID,
+	}
 	_, err := lock.TryLock()
 	if err != nil {
 		return nil, err
@@ -45,7 +51,8 @@ func getConn(pool *sql.DB, cur, maxRetries int) (*sql.Conn, error) {
 	if maxRetries == cur {
 		return nil, fmt.Errorf("max attempts reached. giving up on getting a db connection")
 	}
-	ctx, _ := context.WithTimeout(context.Background(), waitForConnectionTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), waitForConnectionTimeout)
+	defer cancel()
 	lockConn, err := pool.Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting DB connection: %v", err)
@@ -58,59 +65,77 @@ func getConn(pool *sql.DB, cur, maxRetries int) (*sql.Conn, error) {
 	return lockConn, nil
 }
 
-func (l *PgAdvisoryLock) Id() string {
-	return strconv.Itoa(l.groupLockId)
+// ID returns the group lock ID for this instance.
+func (l *PgAdvisoryLock) ID() string {
+	return strconv.Itoa(l.groupLockID)
 }
 
+// BecomeLeader tries to become a leader by acquiring the lock.
 func (l *PgAdvisoryLock) BecomeLeader() (bool, error) {
 	return l.TryLock()
 }
 
+// IsLeader returns the current leader status for this instance.
 func (l *PgAdvisoryLock) IsLeader() (bool, error) {
-	return l.Locked(), nil
+	return l.TryLock()
 }
 
+// Resign releases the leader status of this instance.
 func (l *PgAdvisoryLock) Resign() error {
 	return l.Release()
 }
 
+// TryLock tries to obtain the lock if its not already the leader. In the case
+// that it is the leader, it verifies the connection to make sure the lock hasn't
+// been already lost.
 func (l *PgAdvisoryLock) TryLock() (bool, error) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if l.obtained {
-		err := checkConnection(l.conn)
-		if err != nil {
-			l.obtained = false
-		} else {
-			return l.obtained, nil
-		}
-	}
-	var err error
-	l.conn, err = getConn(l.connPool, 0, 10)
-	defer func() {
-		if !l.obtained {
-			l.connCleanUp()
-		}
-	}()
+	gotLock, err := l.getAdvisoryLock()
 
+	if !gotLock || err != nil {
+		l.obtained = false
+		return false, err
+	}
+
+	if !l.obtained {
+		l.obtained = true
+		log.Debug("msg", fmt.Sprintf("Lock obtained for group id %d", l.groupLockID))
+	}
+
+	return true, nil
+}
+
+func (l *PgAdvisoryLock) getAdvisoryLock() (bool, error) {
+	var err error
+	if l.conn == nil {
+		l.conn, err = getConn(l.connPool, 0, 10)
+	}
 	if err != nil {
 		return false, err
 	}
-	rows, err := l.conn.QueryContext(context.Background(), "SELECT pg_try_advisory_lock($1)", l.groupLockId)
+	defer func() {
+		if err != nil {
+			l.connCleanUp()
+		}
+	}()
+	rows, err := l.conn.QueryContext(context.Background(), "SELECT pg_try_advisory_lock($1)", l.groupLockID)
 	if err != nil {
 		return false, err
 	}
 	defer rows.Close()
 	if !rows.Next() {
-		return false, fmt.Errorf("error while trying to read response rows from `pg_try_advisory_lock` function")
+		err = rows.Err()
+		if err != nil {
+			return false, fmt.Errorf("error while trying to read response rows from `pg_try_advisory_lock` function: %v", err)
+		}
+		return false, fmt.Errorf("missing response row from `pg_try_advisory_lock` function")
 	}
-	if err := rows.Scan(&l.obtained); err != nil {
+	var result bool
+	if err := rows.Scan(&result); err != nil {
 		return false, err
 	}
-	if l.obtained {
-		log.Debug("msg", fmt.Sprintf("Lock obtained for group id %d", l.groupLockId))
-	}
-	return l.obtained, nil
+	return result, nil
 }
 
 func (l *PgAdvisoryLock) connCleanUp() {
@@ -122,19 +147,21 @@ func (l *PgAdvisoryLock) connCleanUp() {
 	l.conn = nil
 }
 
+// Locked returns if the instance was able to obtain the leader lock.
 func (l *PgAdvisoryLock) Locked() bool {
 	l.mutex.RLock()
 	defer l.mutex.RUnlock()
 	return l.obtained
 }
 
+// Release releases the already obtained leader lock.
 func (l *PgAdvisoryLock) Release() error {
 	l.mutex.Lock()
 	if !l.obtained {
 		return fmt.Errorf("can't release while not holding the lock")
 	}
 	defer l.mutex.Unlock()
-	rows, err := l.conn.QueryContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.groupLockId)
+	rows, err := l.conn.QueryContext(context.Background(), "SELECT pg_advisory_unlock($1)", l.groupLockID)
 	if err != nil {
 		return err
 	}
@@ -144,7 +171,7 @@ func (l *PgAdvisoryLock) Release() error {
 		return err
 	}
 	if !success {
-		return fmt.Errorf("failed to release a lock with group lock id: %v", l.groupLockId)
+		return fmt.Errorf("failed to release a lock with group lock id: %v", l.groupLockID)
 	}
 	rows.Close()
 	l.connCleanUp()


### PR DESCRIPTION
In a disaster or failover scenario, advisory lock that was previously
acquired would be lost by the leader instance. In this case, we need to
double check that the connection is down and release the
application-side lock to avoid having a state with multiple leaders.