### PR TITLE
Http Request Duration Histogram should be in seconds unit

### DIFF
--- a/cmd/prometheus-postgresql-adapter/main.go
+++ b/cmd/prometheus-postgresql-adapter/main.go
@@ -92,8 +92,8 @@ var (
 	)
 	httpRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "http_request_duration_ms",
-			Help:    "Duration of HTTP request in milliseconds",
+			Name:    "http_request_duration_seconds",
+			Help:    "Duration of HTTP request in seconds",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"path"},
@@ -396,8 +396,8 @@ func timeHandler(path string, handler http.Handler) http.Handler {
 	f := func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		handler.ServeHTTP(w, r)
-		elapsedMs := time.Since(start).Nanoseconds() / int64(time.Millisecond)
-		httpRequestDuration.WithLabelValues(path).Observe(float64(elapsedMs))
+		elapsedSec := time.Since(start).Nanoseconds() / int64(time.Second)
+		httpRequestDuration.WithLabelValues(path).Observe(float64(elapsedSec))
 	}
 	return http.HandlerFunc(f)
 }


### PR DESCRIPTION
Hi, 
I changed the units of the Http Request Duration Histogram to Seconds.
Here's a link to the official Prometheus documentation where states that base units should be used for any metric, as a best practice.

https://prometheus.io/docs/practices/naming/#metric-names

We are testing this adapter on a project and needed the metric with the right unit in order to  know if http requests are being lost.

Thank You.